### PR TITLE
Implement deletion of multiple keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,18 +133,24 @@ class Endb extends EventEmitter {
 
 	/**
 	 * Removes the specified element from the database by key.
-	 * @param {string} key The key of the element to remove from the database.
-	 * @returns {Promise<boolean>} `true` if an element in the database existed and has been removed, or `false` if the element does not exist.
+	 * @param {string|string[]} key The key(s) of the element to remove from the database.
+	 * @returns {Promise<boolean|boolean[]>} `true` if an element in the database existed and has been removed, or `false` if the element does not exist.
 	 * @example
 	 * const endb = new Endb();
 	 *
-	 * await endb.set('foo', 'bar');
-	 *
+	 * await endb.set('foo', 'bar'); // true
+	 * 
 	 * await endb.delete('foo'); // true
+	 * await endb.delete(['foo', 'fizz']); // [ true, false ]
 	 */
 	delete(key) {
 		key = addKeyPrefix(key, this.options.namespace);
-		return Promise.resolve().then(() => this.options.store.delete(key));
+		return Promise.resolve().then(() => {
+			if (Array.isArray(key)) {
+				return Promise.all(key.map(k => this.options.store.delete(k)));
+			}
+			return this.options.store.delete(key);
+		});
 	}
 
 	async export() {

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ class Endb extends EventEmitter {
 	 * const endb = new Endb();
 	 *
 	 * await endb.set('foo', 'bar'); // true
-	 * 
+	 *
 	 * await endb.delete('foo'); // true
 	 * await endb.delete(['foo', 'fizz']); // [ true, false ]
 	 */
@@ -149,6 +149,7 @@ class Endb extends EventEmitter {
 			if (Array.isArray(key)) {
 				return Promise.all(key.map(k => this.options.store.delete(k)));
 			}
+
 			return this.options.store.delete(key);
 		});
 	}

--- a/src/util.js
+++ b/src/util.js
@@ -5,6 +5,7 @@ module.exports = class Util {
 		if (Array.isArray(key)) {
 			return key.map(k => `${namespace}:${k}`);
 		}
+
 		return `${namespace}:${key}`;
 	}
 

--- a/src/util.js
+++ b/src/util.js
@@ -2,6 +2,9 @@
 
 module.exports = class Util {
 	static addKeyPrefix(key, namespace) {
+		if (Array.isArray(key)) {
+			return key.map(k => `${namespace}:${k}`);
+		}
 		return `${namespace}:${key}`;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,7 +22,7 @@ declare module 'endb' {
     constructor(uri: string, options: EndbOptions);
     public all(): Promise<Element[]>;
     public clear(): Promise<undefined>;
-    public delete(key: string): Promise<boolean>;
+    public delete(key: string | string[]): Promise<boolean|boolean[]>;
     public export(): Promise<string>;
     public find(fn: Function, thisArg: any): Promise<Element | undefined>;
     public get(key: string): Promise<any>;
@@ -34,7 +34,7 @@ declare module 'endb' {
   }
 
   export class Util {
-    public static addKeyPrefix(key: string, namespace: string): string;
+    public static addKeyPrefix(key: string | string[], namespace: string): string;
     public static isBufferLike(x: any): boolean;
     public static isObject(x: any): boolean;
     public static load(options: EndbOptions): any;


### PR DESCRIPTION
You can now pass an array to the Endb#delete method to delete multiple keys.

```js
const endb = new Endb();

await endb.set('foo', 'bar');
await endb.set('k', 'val');
await endb.delete(['foo', 'test', 'k']); // [ true, false, true ]
```