### PR TITLE
feat: implement Endb#ensure method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,33 @@ class Endb extends EventEmitter {
 		});
 	}
 
+	/**
+	 * Ensures if an element exists in the database. If the element does not exist, sets the element to the database.
+	 * @param {string} key The key of the element to ensure.
+	 * @param {*} value The value of the element to ensure. 
+	 * @return {Promise<*>} The (default) value of the element.
+	 * @example
+	 * const endb = new Endb();
+	 * 
+	 * await endb.set('en', 'db');
+	 * 
+	 * const data = await endb.ensure('foo', 'bar');
+	 * console.log(data); // 'bar'
+	 * 
+	 * const el = await endb.ensure('en', 'db');
+	 * console.log(el); // 'db'
+	 */
+	async ensure(key, value) {
+		const element = await this.has(key);
+		if (!element) {
+			await this.set(key, value);
+			return value;
+		} else {
+			const data = await this.get(key);
+			return data;
+		}
+	}
+
 	async export() {
 		return JSON.stringify(
 			{


### PR DESCRIPTION
## Description

The Endb#ensure method ensures if an element exists in the database. If the element does, calls the Endb#get to retrieve the value from the database and finally returns its value. If the element does not, the method calls the Endb#set method to set the element to the database and ultimately returns its value.

## Example

```js
const endb = new Endb();
await endb.set('en', 'db');

const data = await endb.ensure('foo', 'bar');
console.log(data); // 'bar'

const el = await endb.ensure('en', 'db');
console.log(el); // 'db'
```

