### PR TITLE
chore(adapters): switch from events.EventEmitter

### DIFF
--- a/src/adapters/leveldb.js
+++ b/src/adapters/leveldb.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {EventEmitter} = require('events');
+const EventEmitter = require('events');
 const {safeRequire} = require('../util');
 const Level = safeRequire('level');
 

--- a/src/adapters/mongodb.js
+++ b/src/adapters/mongodb.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {EventEmitter} = require('events');
+const EventEmitter = require('events');
 const {safeRequire, removeKeyPrefix} = require('../util');
 const mongojs = safeRequire('mongojs');
 

--- a/src/adapters/redis.js
+++ b/src/adapters/redis.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {EventEmitter} = require('events');
+const EventEmitter = require('events');
 const {safeRequire} = require('../util');
 const Ioredis = safeRequire('ioredis');
 

--- a/src/adapters/sql.js
+++ b/src/adapters/sql.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {EventEmitter} = require('events');
+const EventEmitter = require('events');
 const {removeKeyPrefix, safeRequire} = require('../util');
 const sql = safeRequire('sql');
 


### PR DESCRIPTION
In May 2013, the pull-request was created on the nodejs/node repository.

> The module "events" was exported as EventEmitter to enable slightly simpler/nicer syntax and
adhere to the best practice set forth by sub-stack. The only difference is that we now have to set `EventEmitter` as a property of `EventEmitter` for backward compatibility as we do with `Stream`
> Besides, they have also set the `usingDomains` property on the `EventEmitter`
constructor itself because that aligns with its current usage of `require("events").usingDomains = true;`
> Other internals would benefit from this shift as well like `StringDecoder`
