### PR TITLE
fix: all() returns all the elements disregarding namespaces

### DIFF
--- a/src/adapters/mongodb.js
+++ b/src/adapters/mongodb.js
@@ -36,7 +36,7 @@ module.exports = class MongoDB extends EventEmitter {
 
 	async all() {
 		const collection = await this.db;
-		return collection.find({}).toArray();
+		return collection.find({key: new RegExp(`^${this.namespace}:`)}).toArray();
 	}
 
 	async clear() {
@@ -63,7 +63,7 @@ module.exports = class MongoDB extends EventEmitter {
 
 	async has(key) {
 		const collection = await this.db;
-		return collection.find({key}).limit(1);
+		return collection.find({key}).count() > 0;
 	}
 
 	async set(key, value) {

--- a/src/adapters/redis.js
+++ b/src/adapters/redis.js
@@ -29,8 +29,14 @@ module.exports = class Redis extends EventEmitter {
 	}
 
 	async all() {
-		const data = await this.db.keys('*');
-		return data;
+		const keys = await this.db.keys('*');
+		const elements = [];
+		for (const key of keys) {
+			const value = this.db.get(key);
+			elements.push({key, value});
+		}
+
+		return elements;
 	}
 
 	async clear() {

--- a/src/adapters/sql.js
+++ b/src/adapters/sql.js
@@ -41,7 +41,10 @@ module.exports = class SQL extends EventEmitter {
 	}
 
 	async all() {
-		const select = this.entry.select('*').toString();
+		const select = this.entry
+			.select('*')
+			.where(this.entry.key.like(`${this.namespace}:%`))
+			.toString();
 		const rows = await this.query(select);
 		return rows;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ class Endb extends EventEmitter {
 			for (const [key, value] of store) {
 				elements.push({
 					key: this._removeKeyPrefix(key),
-					value: deserialize(value)
+					value: typeof value === 'string' ? deserialize(value) : value
 				});
 			}
 


### PR DESCRIPTION
[Endb#all()](https://endb.js.org/?api=endb#Endb#all) disregards namespaces and returns all the elements present in the database.

```js
const endb1 = new Endb({ namespace: 'endb1' });
const endb2 = new Endb({ namespace: 'endb2' });

await endb1.set('foo', 'bar);
await endb2.set('fizz, 'buzz');

console.log(await endb1.all()); // [ { key: 'foo', value: 'bar' }, { key: 'endb2:fizz', value: 'buzz' } ]
```