### PR TITLE
Remove support for driver options from the main options

### DIFF
--- a/src/adapters/mongodb.js
+++ b/src/adapters/mongodb.js
@@ -13,24 +13,20 @@ module.exports = class MongoDB extends EventEmitter {
 			...options
 		};
 		this.db = new Promise((resolve) => {
-			mongodb.MongoClient.connect(
-				this.options.url,
-				{useUnifiedTopology: options.useUnifiedTopology || true},
-				(error, client) => {
-					if (error !== null) return this.emit('error', error);
-					const db = client.db();
-					const collection = db.collection(this.options.collection);
-					db.on('error', (error) => this.emit('error', error));
-					collection.createIndex(
-						{key: 1},
-						{
-							unique: true,
-							background: true
-						}
-					);
-					resolve(collection);
-				}
-			);
+			mongodb.MongoClient.connect(this.options.url, (error, client) => {
+				if (error !== null) return this.emit('error', error);
+				const db = client.db();
+				const collection = db.collection(this.options.collection);
+				db.on('error', (error) => this.emit('error', error));
+				collection.createIndex(
+					{key: 1},
+					{
+						unique: true,
+						background: true
+					}
+				);
+				resolve(collection);
+			});
 		});
 	}
 

--- a/src/adapters/mysql.js
+++ b/src/adapters/mysql.js
@@ -5,24 +5,17 @@ const Sql = require('./sql');
 
 module.exports = class MySQL extends Sql {
 	constructor(options = {}) {
-		const options_ = {
-			uri: 'mysql://localhost',
-			...options
-		};
+		const {uri = 'mysql://localhost'} = options;
 		super({
 			dialect: 'mysql',
 			async connect() {
-				if (options_.connectTimeout) {
-					options_.uri += `?connectTimeout=${Number(options.connectTimeout)}`;
-				}
-
-				const connection = await mysql.createConnection(options_.uri);
+				const connection = await mysql.createConnection(uri);
 				return async (sqlString) => {
 					const [row] = await connection.execute(sqlString);
 					return row;
 				};
 			},
-			...options_
+			...options
 		});
 	}
 };

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ class Endb extends EventEmitter {
 		for (const {key, value} of data) {
 			elements.push({
 				key: this._removeKeyPrefix(key),
-				value: deserialize(value)
+				value: typeof value === 'string' ? deserialize(value) : value
 			});
 		}
 


### PR DESCRIPTION
BREAKING CHANGE: the option must be stringified in the URI instead of passing to the Endb instance.

- Before:
```javascript
const endb = new Endb({
  uri: 'mongodb://...',
  useUnifiedTopology: true
});
```
- After:
```javascript
const endb = new Endb({
  uri: 'mongodb://...?useUnifiedTopology=true'
});
```