### PR TITLE
fix(endb#set): add prefix after _.set to avoid fallback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -397,12 +397,13 @@ class Endb extends EventEmitter {
 	 * await endb.set('profile', 100, 'balance');
 	 */
 	async set(key, value, path = null) {
-		key = this._addKeyPrefix(key);
 		const {store, serialize} = this.options;
 		if (path !== null) {
-			value = _set((await this.get(key)) || {}, path, value);
+			const value_ = await this.get(key);
+			value = _set(value_ || {}, path, value);
 		}
 
+		key = this._addKeyPrefix(key);
 		await store.set(key, serialize(value));
 		return true;
 	}


### PR DESCRIPTION
`Endb#set()` overwrites all the properties in an object (or the entire object) when path parameter is used since the retrieved value is undefined (key is prefixed before the usage of `Endb#get()` which is not needed for `Endb#get()`; it, internally, prefixes the key with the namespace).

- Before:
```javascript
await endb.set('foo, 'bar', 'fizz');
console.log(await endb.get('foo')); // -> { fizz: 'bar' }
await endb.set('foo', 'bar', 'buzz');
console.log(await endb.get('foo')); // -> { buzz: 'bar' }
// Expected: { fizz: 'bar', buzz: 'bar' }
```

- After:
```javascript
await endb.set('foo, 'bar', 'fizz');
console.log(await endb.get('foo')); // -> { fizz: 'bar' }
await endb.set('foo', 'bar', 'buzz'); 
console.log(await endb.get('foo'); // -> { fizz: 'bar', buzz: 'bar' }
```