### PR TITLE
chore: switch to conventional commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,12 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
+    "@commitlint/cli": "^8.3.5",
+    "@commitlint/config-conventional": "*",
     "ava": "^3.7.1",
     "coveralls": "^3.1.0",
     "docma": "^3.2.2",
+    "husky": "^4.2.5",
     "mongodb": "^3.5.6",
     "mysql2": "^2.1.0",
     "nyc": "^15.0.1",
@@ -72,5 +75,15 @@
       "unicorn/explicit-length-check": 0,
       "unicorn/no-fn-reference-in-iterator": 0
     }
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }


### PR DESCRIPTION
## What is Conventional Commits

The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages.

## Why Use Conventional Commits

    - Automatically generating CHANGELOGs.
    - Automatically determining a semantic version bump (based on the types of commits landed).
    - Communicating the nature of changes to teammates, the public, and other stakeholders.
    - Triggering build and publish processes.
    - Making it easier for people to contribute to your projects, by allowing them to explore a more structured commit history.

Learn more: [https://www.conventionalcommits.org](https://www.conventionalcommits.org)