### PR TITLE
fix(mongodb): has() returns false even if the key exists

### DIFF
--- a/src/adapters/mongodb.js
+++ b/src/adapters/mongodb.js
@@ -58,7 +58,8 @@ module.exports = class MongoDB extends EventEmitter {
 
 	async has(key) {
 		const collection = await this.db;
-		return collection.find({key}).count() > 0;
+		const doc = await collection.findOne({key});
+		return Boolean(doc);
 	}
 
 	async set(key, value) {


### PR DESCRIPTION
EndbMongo#has(key) returns false even if the key is existent.

Closes #70